### PR TITLE
Octave Support for `isethdrsensor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ Special thanks to the developers of ISETCam, ISETAuto, and ISET3d for their inva
 - July 14, 2025: Ayush Jamdar.
 - We've modified EXR handling and other scripts in `isetcam` and `iset3d-tiny` that can read the light groups using OpenEXR and simulate the complete pipeline in GNU Octave. 
 - We have tested `isethdrsensor/scripts/fullSimulation.m` on examples from the ISET HDR dataset using Octave 6.4.0.
+- Refer to `isetcam/README.md` for Octave and Conda environment packages.

--- a/README.md
+++ b/README.md
@@ -98,3 +98,9 @@ This project is licensed under the [MIT License](LICENSE).
 ## Acknowledgments
 
 Special thanks to the developers of ISETCam, ISETAuto, and ISET3d for their invaluable tools that made this work possible.
+
+## Octave Support
+- July 14, 2025: Ayush Jamdar at Omnivision Technologies Inc.
+- We've modified EXR handling and other scripts in `isetcam` and `iset3d-tiny` that can read the light groups using OpenEXR and simulate the complete pipeline in GNU Octave. 
+- We have tested `isethdrsensor/scripts/fullSimulation.m` on examples from the ISET HDR dataset.
+

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ This project is licensed under the [MIT License](LICENSE).
 Special thanks to the developers of ISETCam, ISETAuto, and ISET3d for their invaluable tools that made this work possible.
 
 ## Octave Support
-- July 14, 2025: Ayush Jamdar at Omnivision Technologies Inc.
+- July 14, 2025: Ayush Jamdar.
 - We've modified EXR handling and other scripts in `isetcam` and `iset3d-tiny` that can read the light groups using OpenEXR and simulate the complete pipeline in GNU Octave. 
-- We have tested `isethdrsensor/scripts/fullSimulation.m` on examples from the ISET HDR dataset.
-
+- We have tested `isethdrsensor/scripts/fullSimulation.m` on examples from the ISET HDR dataset using Octave 6.4.0.

--- a/scripts/fullSimulation.m
+++ b/scripts/fullSimulation.m
@@ -5,7 +5,7 @@
 % 
 % We simulate the ISET implementation of OVT's 
 % split pixel technology
-% Authored by Ayush Jamdar at Omnivision Technologies Inc. 
+% Authored by Ayush Jamdar. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Stage 0. Setup

--- a/scripts/fullSimulation.m
+++ b/scripts/fullSimulation.m
@@ -5,6 +5,7 @@
 % 
 % We simulate the ISET implementation of OVT's 
 % split pixel technology
+% Authored by Ayush Jamdar at Omnivision Technologies Inc. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Stage 0. Setup

--- a/scripts/fullSimulation.m
+++ b/scripts/fullSimulation.m
@@ -1,0 +1,114 @@
+% The goal of this script is to 
+% 1. Simulate the entire digital imaging pipeline
+%    in the Linux-Octave setup
+% 2. Play around with hyperparameters
+% 
+% We simulate the ISET implementation of OVT's 
+% split pixel technology
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Stage 0. Setup
+disp('Running Stage 0: Setup');
+
+ieInit; % start a global vcSession which stores states. 
+% runs fully locally. 
+
+% 0.A Scene Setup
+imageID = '1112201236';
+wgts = [0.2306    0.012    0.01    1e-2*0.5175];  % night
+% Headlight, Street light, Other, Sky light: weight ordering
+
+
+% 0.B Camera Optics Setup
+[oi,wvf] = oiCreate('wvf');  % create an optical image and wavefront
+params = wvfApertureP;  % aperture parameters
+params.nsides = 3;
+params.dotmean = 50;  % dots simulate dust particles
+params.dotsd = 20;
+params.dotopacity =0.5;
+params.dotradius = 5;
+params.linemean = 50;  % lins simulate scratches
+params.linesd = 20;
+params.lineopacity = 0.5;
+params.linewidth = 2;
+
+aperture = wvfAperture(wvf,params);
+oi = oiSet(oi,'wvf zcoeffs',0,'defocus');
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Stage I. Scene Radiance to Sensor Irradiance
+% Pass light through the optics
+disp('Running Stage I: Optics');
+scene = hsSceneCreate(imageID,'weights',wgts,'denoise',false);
+opticalImage = oiCompute(oi, scene,'aperture',aperture,'crop',true,'pixel size',3e-6);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Stage II. Sensor Modelling & Capture
+disp('Running Stage II: Sensor Capture');
+
+% hyperparameters
+expTime = 16e-3;
+satLevel = 0.95;
+pixelSize = 3e-6;  % 3 um
+sensorSize = [1082 1926];  % resolution
+
+arrayType = 'ovt';
+
+% the split pixel tech is essentially running three sensors
+% LPD-LCG, LPD-HCG, SPD 
+% sensorArray is an array of these three sensors (in ORDER)
+sensorArray = sensorCreateArray('array type',arrayType,...
+    'pixel size same fill factor',pixelSize,...
+    'exp time',expTime, ...
+    'quantizationmethod','analog', ...
+    'size',sensorSize);
+
+% sensor capture
+%   sensorCombined   - Data pooled from the multiple sensors in the array
+%   sensorArraySplit - The individual sensors
+[sensorCombined,sensorArraySplit] = sensorComputeArray(sensorArray,opticalImage,...
+    'method','saturated', ...
+    'saturated',satLevel);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Stage III. Image Processing
+disp('Running Stage III: Image Processing');
+ipLPD = ipCreate;
+sensorLPDLCG = sensorArraySplit(1);
+ipLPDLCG = ipCompute(ipLPD,sensorLPDLCG,'hdr white',true);
+% ipWindow(ipLPDLCG,'render flag','rgb','gamma',0.5);
+
+ipLPDHCG = ipCreate;
+sensorLPDHCG = sensorArraySplit(2);
+ipLPDHCG = ipCompute(ipLPDHCG,sensorLPDHCG,'hdr white',true);
+% ipWindow(ipLPDHVG,'render flag','rgb','gamma',0.5);
+
+ipSPD = ipCreate;
+sensorSPD = sensorArraySplit(3);
+ipSPD = ipCompute(ipSPD,sensorSPD,'hdr white',true);
+% ipWindow(ipSPD,'render flag','rgb','gamma',0.5);
+
+ipSplit = ipCreate;
+ipSplit = ipCompute(ipSplit,sensorCombined,'hdr white',true);
+% ipWindow(ipSplit,'render flag','rgb','gamma',0.5);
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Stage IV. Save & Display
+disp('Running Stage IV: Save Outputs');
+
+rgb = ipGet(ipSplit,'srgb');
+fname = fullfile(isethdrsensorRootPath,'data', imageID,'split.png');
+imwrite(rgb,fname);
+
+rgb = ipGet(ipLPDLCG,'srgb');
+fname = fullfile(isethdrsensorRootPath,'data', imageID,'lpd-lcg.png');
+imwrite(rgb,fname);
+
+rgb = ipGet(ipLPDHCG,'srgb');
+fname = fullfile(isethdrsensorRootPath,'data', imageID, 'lpd-hcg.png');
+imwrite(rgb,fname);
+
+rgb = ipGet(ipSPD,'srgb');
+fname = fullfile(isethdrsensorRootPath,'data', imageID,'spd.png');
+imwrite(rgb,fname);

--- a/scripts/s_hsSplitPixelParameters.m
+++ b/scripts/s_hsSplitPixelParameters.m
@@ -21,8 +21,8 @@
 %%
 ieInit;
 
-% imageID = '1112201236'; % - Good one
-imageID = '1114091636';   % Red car, green car
+imageID = '1112201236'; % - Good one
+% imageID = '1114091636';   % Red car, green car
 
 %% Day scene weights
 
@@ -50,13 +50,12 @@ oi = oiSet(oi,'wvf zcoeffs',0,'defocus');
 
 %%  If you want the oiDay, this is how
 
-%{
 wgts = [0    0     0    100*0.5175]; % Day
 scene = hsSceneCreate(imageID,'weights',wgts,'denoise',false);
 oiDay = oiCompute(oi, scene,'aperture',aperture,'crop',true,'pixel size',3e-6);
-oiWindow(oiDay,'gamma',0.5,'render flag','rgb');
-srgb = oiGet(oiDay,'rgb'); ieNewGraphWin; image(srgb); truesize
-%}
+% oiWindow(oiDay,'gamma',0.5,'render flag','rgb');
+% srgb = oiGet(oiDay,'rgb'); ieNewGraphWin; image(srgb); truesize
+
 
 %% Night scene weights
 
@@ -64,10 +63,10 @@ srgb = oiGet(oiDay,'rgb'); ieNewGraphWin; image(srgb); truesize
 
 % Experimenting with how dark.  4 log units down gets night
 % But three really doesn't.
-wgts    = [0.2306    0.0012    0.0001    1e-2*0.5175]; % Night
-scene   = hsSceneCreate(imageID,'weights',wgts,'denoise',true);
-oiNight = oiCompute(oi, scene,'aperture',aperture,'crop',true,'pixel size',3e-6);
-oiWindow(oiNight,'render flag','rgb','gamma',0.2);
+% wgts    = [0.2306    0.0012    0.0001    1e-2*0.5175]; % Night
+% scene   = hsSceneCreate(imageID,'weights',wgts,'denoise',false);
+% oiNight = oiCompute(oi, scene,'aperture',aperture,'crop',true,'pixel size',3e-6);
+% oiWindow(oiNight,'render flag','rgb','gamma',0.2);
 
 % save(sprintf('oiNight-%d',imageID),'oiNight');
 
@@ -80,12 +79,13 @@ oiWindow(oiNight,'render flag','rgb','gamma',0.2);
 
 pixelSize = 3e-6;
 sensorSize = [1082 1926];
-sensorArray = sensorCreateArray('array type','imx490',...
+arrayType = 'ovt';
+sensorArray = sensorCreateArray('array type', arrayType,...
     'pixel size same fill factor',pixelSize,...
     'exp time',16e-3, ...
     'size',sensorSize);
 
-sensorSplit = sensorComputeArray(sensorArray,oiNight);
+sensorSplit = sensorComputeArray(sensorArray,oiDay);
 % sensorWindow(sensorSplit,'gamma',0.3);
 %{
  rgb = sensorGet(sensorSplit,'rgb');
@@ -96,7 +96,7 @@ sensorSplit = sensorComputeArray(sensorArray,oiNight);
 
 ip = ipCreate;
 ip = ipCompute(ip,sensorSplit);
-ipWindow(ip,'render flag','rgb','gamma',0.3);
+% ipWindow(ip,'render flag','rgb','gamma',0.3);
 
 %% Here are some key parameters
 

--- a/utility/hsSceneCreate.m
+++ b/utility/hsSceneCreate.m
@@ -54,21 +54,31 @@ fname = fullfile(p.Results.datadir,sprintf('HDR-scenes-%s.mat',imageID));
 if exist(fname,'file')
     load(fname,'scenes','sceneMeta');
 else
-    try
+    % try
         lgt = {'headlights','streetlights','otherlights','skymap'};
         destPath = fullfile(isethdrsensorRootPath,'data',imageID);
+        disp(destPath);
 
         scenes = cell(numel(lgt,1));
         for ll = 1:numel(lgt)
             thisFile = sprintf('%s_%s.exr',imageID,lgt{ll});
             destFile = fullfile(destPath,thisFile);
+
+            if exist(destFile, 'file')
+                sprintf('%s: File exists.', destFile);
+            else
+                sprintf('%s: File does not exist.', destFile);
+            end
+
             scenes{ll} = piEXR2ISET(destFile);
         end
         destPath = fullfile(isethdrsensorRootPath,'data',imageID);
         load(fullfile(destPath,[imageID,'.mat']),'sceneMeta');
-    catch
-        error('Light group ID %s not found in isethdrsensor/data.\n',imageID);
-    end
+    % catch ME
+    %     fprintf('Error ID: %s\n', ME.identifier);
+    %     fprintf('Message: %s\n', ME.message);
+    %     error('Light group ID %s not found in isethdrsensor/data.\n',imageID);
+    % end
 end
 
 %%  Combine them


### PR DESCRIPTION
While ISET is an amazing simulation tool, it depends on its user's having paid MATLAB licenses which might not be accessible to all individuals and organizations interested in using the toolbox.
 
GNU Octave is a free and open-source alternative for MATLAB. It imitates most MATLAB functionality with code and CLI but has different libraries, toolboxes, and datatypes.  One third-party package of importance in `isethdrsensor` is `openexr`. With help from Brian and David, I was able to modify the current ISET codebase to work with Octave 6.4.0.

The changes are briefly described at the end of `README.md` and the necessary packages are listed in another PR opened in the `isetcam`  repository. 

This PR goes along with the two others opened in `isetcam` and `iset3d-tiny` repos. All my branches are named `dev-octave`.

I have tested this code on Octave 6.4.0 using a conda environment as detailed in `isetcam/environment.yml`.

Hope this helps extend access to ISET!